### PR TITLE
LAO-528 Switch to ubuntu to fix exim vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM debian:buster
-
-MAINTAINER Oluwaseun Obajobi "oluwaseun.obajobi@namshi.com"
+FROM ubuntu:24.10
 
 RUN apt-get update && \
     apt-get install -y exim4-daemon-light && \


### PR DESCRIPTION
We have been waiting for Tollring on this ticket so we can switch to destiny smtp service.

In the meantime, we can use the latest exim available in latest ubuntu image (could not find fixed ones in debian latest or ubuntu lts 24.04).

If the 21st maintenance suites, we can switch to a newer solunodev/smtp image based on this image instead (instead of namshi/smtp, 4 years old and unmaintained - I forked that repo for this one).